### PR TITLE
Meson build system support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,43 @@
+project(
+  'wingetopt',
+  'c',
+  version: '0.95',
+  license : ['ISC', 'BSD-3-Clause'],
+  meson_version: '>= 0.55',
+  default_options: [
+    'warning_level=1',
+  ],
+)
+
+compiler = meson.get_compiler('c')
+
+c_args = []
+
+if compiler.get_id() == 'msvc'
+  c_args += [
+    '-D_CRT_SECURE_NO_WARNINGS',
+  ]
+
+  if get_option('default_library') == 'shared'
+    c_args += [
+      '-DBUILDING_WINGETOPT_DLL',
+      '-DWINGETOPT_SHARED_LIB',
+    ]
+  endif
+endif
+
+wingetopt_lib = library(
+  'wingetopt',
+  'src/getopt.c',
+  include_directories: include_directories(
+    'src',
+  ),
+  c_args: c_args,
+)
+
+wingetopt_dep = declare_dependency(
+  link_with: wingetopt_lib,
+  include_directories: include_directories(
+    'src',
+  ),
+)


### PR DESCRIPTION
This is a simple Meson build system support, verified to work with MSVC on Windows Server 2019 using GitHub Actions in [mediasoup](https://github.com/versatica/mediasoup) project: https://github.com/nazar-pc/mediasoup/runs/3391317676?check_suite_focus=true