### PR TITLE
Update meson.build to add install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.31)
 project(wingetopt)
 
 option(BUILD_SHARED_LIBS "Build the shared library" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5...3.31)
 project(wingetopt VERSION 1.0.0 LANGUAGES C)
 
+string(REGEX REPLACE "/W[3|4]" "/w4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 # Define source directory
@@ -14,7 +16,6 @@ target_include_directories(wingetopt PUBLIC
     $<BUILD_INTERFACE:${WINGETOPT_SRC_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-
 # Definitions
 target_compile_definitions(wingetopt PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 if(BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,42 @@
 cmake_minimum_required(VERSION 3.5...3.31)
-project(wingetopt)
+project(wingetopt VERSION 1.0.0 LANGUAGES C)
 
-option(BUILD_SHARED_LIBS "Build the shared library" OFF)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+# Define source directory
+set(WINGETOPT_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+# Library target
+add_library(wingetopt ${WINGETOPT_SRC_DIR}/getopt.c)
 
+# Include directories
+target_include_directories(wingetopt PUBLIC
+    $<BUILD_INTERFACE:${WINGETOPT_SRC_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Definitions
+target_compile_definitions(wingetopt PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 if(BUILD_SHARED_LIBS)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-  add_definitions(-DBUILDING_WINGETOPT_DLL -DWINGETOPT_SHARED_LIB)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    target_compile_definitions(wingetopt PRIVATE -DBUILDING_WINGETOPT_DLL -DWINGETOPT_SHARED_LIB)
 endif()
 
-add_library(wingetopt src/getopt.c src/getopt.h)
+# Install headers
+install(FILES ${WINGETOPT_SRC_DIR}/getopt.h DESTINATION include)
 
-install(FILES src/getopt.h DESTINATION include)
-
+# Install target
 install(TARGETS wingetopt
+    EXPORT wingetoptTargets
     RUNTIME DESTINATION bin
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib)
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    INCLUDES DESTINATION include
+)
 
+# Export for config-based usage
+install(EXPORT wingetoptTargets
+    FILE wingetoptTargets.cmake
+    NAMESPACE wingetopt::
+    DESTINATION lib/cmake/wingetopt
+)

--- a/meson.build
+++ b/meson.build
@@ -33,7 +33,10 @@ wingetopt_lib = library(
     'src',
   ),
   c_args: c_args,
+  install: true,
 )
+
+install_headers('src/getopt.h')
 
 wingetopt_dep = declare_dependency(
   link_with: wingetopt_lib,

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wingetopt',
   'c',
-  version: '0.95',
+  version: '1.00',
   license : ['ISC', 'BSD-3-Clause'],
   meson_version: '>= 0.55',
   default_options: [

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -519,7 +519,7 @@ start:
  *
  * [eventually this will replace the BSD getopt]
  */
-int
+WINGETOPT_API int
 getopt(int nargc, char * const *nargv, const char *options)
 {
 
@@ -539,7 +539,7 @@ getopt(int nargc, char * const *nargv, const char *options)
  * getopt_long --
  *	Parse argc/argv argument vector.
  */
-int
+WINGETOPT_API int
 getopt_long(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx)
 {
@@ -552,7 +552,7 @@ getopt_long(int nargc, char * const *nargv, const char *options,
  * getopt_long_only --
  *	Parse argc/argv argument vector.
  */
-int
+WINGETOPT_API int
 getopt_long_only(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx)
 {

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -36,7 +36,7 @@ WINGETOPT_API extern int opterr;		/* flag to enable built-in diagnostics... */
 
 WINGETOPT_API extern char *optarg;		/* pointer to argument of current option  */
 
-extern int getopt(int nargc, char * const *nargv, const char *options);
+WINGETOPT_API extern int getopt(int nargc, char * const *nargv, const char *options);
 
 #ifdef _BSD_SOURCE
 /*
@@ -46,7 +46,7 @@ extern int getopt(int nargc, char * const *nargv, const char *options);
  * to maintain portability, developers are advised to avoid it.
  */
 # define optreset  __mingw_optreset
-extern int optreset;
+WINGETOPT_API extern int optreset;
 #endif
 #ifdef __cplusplus
 }
@@ -84,9 +84,9 @@ enum    		/* permitted values for its `has_arg' field...	*/
   optional_argument		/* option may take an argument		*/
 };
 
-extern int getopt_long(int nargc, char * const *nargv, const char *options,
+WINGETOPT_API extern int getopt_long(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx);
-extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
+WINGETOPT_API extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx);
 /*
  * Previous MinGW implementation had...


### PR DESCRIPTION
The meson.build doesn't have the ability to install with `meson install` command.

By adding install support to meson.build the meson install command will work. This also will support the creation of other meson projects that want to be able to install and depend on wingetopt meson project.

NOTE: The changes do not cause the wingetopt project to be installed when building.

Thanks,
SLDR
(Stephen L. De Rudder)
