### PR TITLE
Export getopt, getopt_long, and getopt_long_only functions along with optreset global var

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wingetopt',
   'c',
-  version: '0.95',
+  version: '1.00',
   license : ['ISC', 'BSD-3-Clause'],
   meson_version: '>= 0.55',
   default_options: [

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -519,7 +519,7 @@ start:
  *
  * [eventually this will replace the BSD getopt]
  */
-int
+WINGETOPT_API int
 getopt(int nargc, char * const *nargv, const char *options)
 {
 
@@ -539,7 +539,7 @@ getopt(int nargc, char * const *nargv, const char *options)
  * getopt_long --
  *	Parse argc/argv argument vector.
  */
-int
+WINGETOPT_API int
 getopt_long(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx)
 {
@@ -552,7 +552,7 @@ getopt_long(int nargc, char * const *nargv, const char *options,
  * getopt_long_only --
  *	Parse argc/argv argument vector.
  */
-int
+WINGETOPT_API int
 getopt_long_only(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx)
 {

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -36,7 +36,7 @@ WINGETOPT_API extern int opterr;		/* flag to enable built-in diagnostics... */
 
 WINGETOPT_API extern char *optarg;		/* pointer to argument of current option  */
 
-extern int getopt(int nargc, char * const *nargv, const char *options);
+WINGETOPT_API extern int getopt(int nargc, char * const *nargv, const char *options);
 
 #ifdef _BSD_SOURCE
 /*
@@ -46,7 +46,7 @@ extern int getopt(int nargc, char * const *nargv, const char *options);
  * to maintain portability, developers are advised to avoid it.
  */
 # define optreset  __mingw_optreset
-extern int optreset;
+WINGETOPT_API extern int optreset;
 #endif
 #ifdef __cplusplus
 }
@@ -84,9 +84,9 @@ enum    		/* permitted values for its `has_arg' field...	*/
   optional_argument		/* option may take an argument		*/
 };
 
-extern int getopt_long(int nargc, char * const *nargv, const char *options,
+WINGETOPT_API extern int getopt_long(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx);
-extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
+WINGETOPT_API extern int getopt_long_only(int nargc, char * const *nargv, const char *options,
     const struct option *long_options, int *idx);
 /*
  * Previous MinGW implementation had...


### PR DESCRIPTION
When creating a DLL none of the functions are exported.

I also set the version in meson.build to "1.00".

SLDR